### PR TITLE
Fix unused variable warning in wavetable generation

### DIFF
--- a/build/alu_hex.rb
+++ b/build/alu_hex.rb
@@ -91,7 +91,7 @@ def print_wav(offset, opts = {})
 #           first(256).map {|i| i&0xFF}                 # sample 256 and convert to byte
       else
         w = 256.times.map do |i|
-          l = h.first(a+1).each_with_index.map do |j,k| # limit band to a+1
+          h.first(a+1).each_with_index.map do |j,k|     # limit band to a+1
             a.even? && k.odd? ? 0 : j[i]/(k+1)          # skip even harmonics on even a
           end.reduce(&:+)                               # sum harmonics
         end


### PR DESCRIPTION
## Summary
- clean up `build/alu_hex.rb` wavetable synthesis code
- remove an unused local variable to silence Ruby warnings

## Testing
- `ruby -wc build/alu_hex.rb`

------
https://chatgpt.com/codex/tasks/task_e_6872d9ac70c8832fbe19d063810b2e36