### PR TITLE
Fix Ruby ambiguous regexp warning

### DIFF
--- a/build/asm_hex.rb
+++ b/build/asm_hex.rb
@@ -149,7 +149,7 @@ srcs.each do |src|
       b = a.split.first
       next unless b&.start_with? '$'
 
-      d = a.partition /\s+/
+      d = a.partition(/\s+/)
       e = d.first[1..-1]&.strip
       vars[e] = d[2].strip if vars[e].nil?
     end


### PR DESCRIPTION
## Summary
- fix ambiguous regexp in `build/asm_hex.rb` by adding parentheses

## Testing
- `ruby -wc build/asm_hex.rb`

------
https://chatgpt.com/codex/tasks/task_e_6872d998ce54832f8b37e8ca40e97ba7